### PR TITLE
Switched submodules' remote URLs to HTTPS rather than SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "daogenerator"]
 	path = daogenerator
-	url = git@bitbucket.org:lduparc/daogenerator-android.git
+	url = https://bitbucket.org/lduparc/daogenerator-android.git
 [submodule "mutex"]
 	path = mutex
-	url = git@github.com:codlab/android_process_mutex.git
+	url = https://github.com/codlab/android_process_mutex.git


### PR DESCRIPTION
This project does not need to push to these repositories, so HTTPS is sufficient since it does not require a public key with bitbucket and github.