### PR TITLE
Fixed a few bugs that were being revealed by the unit tests

### DIFF
--- a/app/src/main/java/com/wikaba/ogapp/agent/models/FleetEvent.java
+++ b/app/src/main/java/com/wikaba/ogapp/agent/models/FleetEvent.java
@@ -67,9 +67,9 @@ public class FleetEvent implements Comparable<FleetEvent> {
         fleet = new HashMap<String, Long>();
         resources = new FleetResources();
 
-        //originFleet = "";
+        originFleet = "";
         //coordsOrigin = new LinkHTML();
-        //destFleet = "";
+        destFleet = "";
         //destCoords = new LinkHTML();
     }
 

--- a/app/src/main/java/com/wikaba/ogapp/agent/parsers/AbstractParser.java
+++ b/app/src/main/java/com/wikaba/ogapp/agent/parsers/AbstractParser.java
@@ -24,6 +24,7 @@ import com.wikaba.ogapp.agent.models.LinkHTML;
 
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.xmlpull.v1.XmlPullParser;
 
@@ -91,9 +92,7 @@ public abstract class AbstractParser<T> {
 
     private void stripTagsInternal(StringBuilder builder, List<Node> node_list) {
         for (Node node : node_list) {
-            String nodeName = node.nodeName();
-
-            if (nodeName.equalsIgnoreCase("#text")) {
+            if (node instanceof TextNode) {
                 builder.append(node.toString());
             } else {
                 //TODO LINEAR CALL WITH TEMPORARY LIST

--- a/app/src/main/java/com/wikaba/ogapp/agent/parsers/FleetEventParser.java
+++ b/app/src/main/java/com/wikaba/ogapp/agent/parsers/FleetEventParser.java
@@ -99,9 +99,9 @@ public class FleetEventParser extends AbstractParser<List<FleetEvent>> {
             for (Element td : tds) {
                 Element span = td.getElementsByTag("span").first();
                 if (td.hasClass("originFleet")) {
-                    if (span != null) event.originFleet = stripTags(span.childNodes());
+					event.originFleet = stripTags(td.childNodes()).trim();
                 } else if (td.hasClass("destFleet")) {
-                    if (span != null) event.destFleet = stripTags(span.childNodes());
+					event.destFleet = stripTags(td.childNodes()).trim();
                 } else if (td.hasClass("coordsOrigin")) {
                     event.coordsOrigin = extractFirstLink(td);
                 } else if (td.hasClass("destCoords")) {


### PR DESCRIPTION
The biggest issue was using span elements to help determine when the originFleet and destFleet text elements were found. This led to some events not getting parsed completely since not all types of events have a corresponding span element. This can be seen by checking the deployment missions from app/src/androidTest/resources/com/wikaba/ogapp/agent/parsers/lots_of_events.html file.

Otherwise, the other parts in this pull request include small things, like following JSoup's recommended usage of instanceof for determining the type of Node rather than using nodeName, or adding in curly braces.